### PR TITLE
Adjust env var name to match tutorial

### DIFF
--- a/001-quickstart/Program.cs
+++ b/001-quickstart/Program.cs
@@ -8,7 +8,7 @@ using MongoDB.Driver;
 
 // <client_credentials> 
 // New instance of CosmosClient class
-var client = new MongoClient(Environment.GetEnvironmentVariable("MONGO_CONNECTION"));
+var client = new MongoClient(Environment.GetEnvironmentVariable("COSMOS_CONNECTION_STRING"));
 // </client_credentials>
 
 // <new_database> 


### PR DESCRIPTION
The associated markdown file specifies a different environment variable name (`COSMOS_CONNECTION_STRING`) than this example program (currently `MONGO_CONNECTION`):

https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/cosmos-db/mongodb/includes/environment-variables-connection-string.md
referenced from: https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/cosmos-db/mongodb/quickstart-dotnet.md#configure-environment-variables

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
N/A

* Test the code
N/A

## What to Check
Environment variable name for Cosmos Mongo connection string match in Quickstart markdown and C# snippets.

## Other Information
None